### PR TITLE
chore: relicense HDP from CC BY 4.0 to Apache License 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,201 @@
-Creative Commons Attribution 4.0 International License (CC BY 4.0)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Helixar Limited
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-You are free to:
+   1. Definitions.
 
-  Share — copy and redistribute the material in any medium or format
-  Adapt — remix, transform, and build upon the material for any purpose,
-          even commercially.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Under the following terms:
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-  Attribution — You must give appropriate credit to Helixar Limited,
-                provide a link to the license, and indicate if changes were
-                made. You may do so in any reasonable manner, but not in any
-                way that suggests Helixar Limited endorses you or your use.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-  No additional restrictions — You may not apply legal terms or technological
-                               measures that legally restrict others from doing
-                               anything the license permits.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-Full license text: https://creativecommons.org/licenses/by/4.0/legalcode
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file's name and extension may appear on the first line of the file's
+      description page. Include a boilerplate notice at the top of every
+      file that is part of this work.
+
+   Copyright 2026 Helixar Limited
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _Every action an AI agent takes, traceable back to the human who authorized it._
 [![npm version](https://img.shields.io/npm/v/@helixar_ai/hdp?style=flat-square&logo=npm&logoColor=white&color=0ea5e9)](https://www.npmjs.com/package/@helixar_ai/hdp)
 [![PyPI hdp-crewai](https://img.shields.io/pypi/v/hdp-crewai?style=flat-square&logo=pypi&logoColor=white&color=0ea5e9&label=hdp-crewai)](https://pypi.org/project/hdp-crewai/)
 [![PyPI hdp-grok](https://img.shields.io/pypi/v/hdp-grok?style=flat-square&logo=pypi&logoColor=white&color=7c3aed&label=hdp-grok)](https://pypi.org/project/hdp-grok/)
-[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg?style=flat-square)](https://creativecommons.org/licenses/by/4.0/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](https://www.apache.org/licenses/LICENSE-2.0)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Python](https://img.shields.io/badge/Python-%3E%3D3.10-3776ab?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D18-339933?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org/)
@@ -773,4 +773,4 @@ If you use HDP in your research, please cite:
 
 ## License
 
-[CC BY 4.0](./LICENSE) — Helixar Limited
+[Apache License 2.0](./LICENSE) — Helixar Limited

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "CC-BY-4.0",
+  "license": "Apache-2.0",
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/Helixar-AI/HDP/issues"

--- a/packages/hdp-autogen-ts/README.md
+++ b/packages/hdp-autogen-ts/README.md
@@ -114,4 +114,4 @@ Human Delegation Provenance (HDP) is an IETF draft:
 
 ## License
 
-[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) — Helixar Limited
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) — Helixar Limited

--- a/packages/hdp-autogen-ts/package.json
+++ b/packages/hdp-autogen-ts/package.json
@@ -32,5 +32,5 @@
     "url": "git+https://github.com/Helixar-AI/HDP.git",
     "directory": "packages/hdp-autogen-ts"
   },
-  "license": "CC-BY-4.0"
+  "license": "Apache-2.0"
 }

--- a/packages/hdp-autogen/README.md
+++ b/packages/hdp-autogen/README.md
@@ -195,4 +195,4 @@ Human Delegation Provenance (HDP) is an IETF draft:
 
 ## License
 
-[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) — Helixar Limited
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) — Helixar Limited

--- a/packages/hdp-autogen/pyproject.toml
+++ b/packages/hdp-autogen/pyproject.toml
@@ -7,7 +7,7 @@ name = "hdp-autogen"
 version = "0.1.2"
 description = "HDP (Human Delegation Provenance) middleware for AutoGen — cryptographic audit trail for multi-agent delegation"
 readme = "README.md"
-license = { text = "CC-BY-4.0" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "pyautogen~=0.2.0",

--- a/packages/hdp-cli/package.json
+++ b/packages/hdp-cli/package.json
@@ -25,5 +25,5 @@
     "url": "git+https://github.com/Helixar-AI/HDP.git",
     "directory": "packages/hdp-cli"
   },
-  "license": "CC-BY-4.0"
+  "license": "Apache-2.0"
 }

--- a/packages/hdp-crewai/README.md
+++ b/packages/hdp-crewai/README.md
@@ -117,4 +117,4 @@ Human Delegation Provenance (HDP) is an IETF draft:
 
 ## License
 
-[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) — Helixar Limited
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) — Helixar Limited

--- a/packages/hdp-crewai/pyproject.toml
+++ b/packages/hdp-crewai/pyproject.toml
@@ -7,7 +7,7 @@ name = "hdp-crewai"
 version = "0.1.2"
 description = "HDP (Human Delegation Provenance) middleware for CrewAI — cryptographic audit trail for multi-agent task delegation"
 readme = "README.md"
-license = { text = "CC-BY-4.0" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "crewai>=0.80.0",

--- a/packages/hdp-grok/README.md
+++ b/packages/hdp-grok/README.md
@@ -121,4 +121,4 @@ Tokens produced by `hdp-grok` use the same Ed25519 + RFC 8785 wire format as the
 
 ## License
 
-CC-BY-4.0
+Apache-2.0

--- a/packages/hdp-grok/pyproject.toml
+++ b/packages/hdp-grok/pyproject.toml
@@ -7,7 +7,7 @@ name = "hdp-grok"
 version = "0.1.1"
 description = "HDP (Human Delegation Provenance) middleware for Grok / xAI API"
 readme = "README.md"
-license = { text = "CC-BY-4.0" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "cryptography>=42.0.0",

--- a/packages/hdp-langchain/README.md
+++ b/packages/hdp-langchain/README.md
@@ -225,4 +225,4 @@ Human Delegation Provenance (HDP) is an IETF draft:
 
 ## License
 
-[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) — Helixar Limited
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) — Helixar Limited

--- a/packages/hdp-langchain/pyproject.toml
+++ b/packages/hdp-langchain/pyproject.toml
@@ -7,7 +7,7 @@ name = "hdp-langchain"
 version = "0.1.0"
 description = "HDP (Human Delegation Provenance) middleware for LangChain — cryptographic audit trail for multi-agent delegation"
 readme = "README.md"
-license = { text = "CC-BY-4.0" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.2.0",

--- a/packages/hdp-llamaindex/pyproject.toml
+++ b/packages/hdp-llamaindex/pyproject.toml
@@ -7,7 +7,7 @@ name = "hdp-llamaindex"
 version = "0.1.0"
 description = "HDP (Human Delegation Provenance) integration for LlamaIndex — metapackage"
 readme = "README.md"
-license = { text = "CC-BY-4.0" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "llama-index-callbacks-hdp>=0.1.0",

--- a/packages/hdp-mcp/package.json
+++ b/packages/hdp-mcp/package.json
@@ -32,5 +32,5 @@
     "url": "git+https://github.com/Helixar-AI/HDP.git",
     "directory": "packages/hdp-mcp"
   },
-  "license": "CC-BY-4.0"
+  "license": "Apache-2.0"
 }

--- a/packages/hdp-physical-py/README.md
+++ b/packages/hdp-physical-py/README.md
@@ -86,4 +86,4 @@ asyncio.run(main())
 
 ## License
 
-CC-BY-4.0 — Helixar AI
+Apache-2.0 — Helixar AI

--- a/packages/hdp-physical-py/pyproject.toml
+++ b/packages/hdp-physical-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "hdp-physical"
 version = "0.1.0"
 description = "HDP-P — Embodied Delegation Tokens and pre-execution safety for physical AI agents"
 readme = "README.md"
-license = { text = "CC-BY-4.0" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "cryptography>=42.0.0",

--- a/packages/hdp-physical/README.md
+++ b/packages/hdp-physical/README.md
@@ -112,4 +112,4 @@ For the full protocol background, threat model, and companion specification:
 
 ## License
 
-CC-BY-4.0 — Helixar AI
+Apache-2.0 — Helixar AI

--- a/packages/hdp-physical/package.json
+++ b/packages/hdp-physical/package.json
@@ -34,5 +34,5 @@
     "url": "git+https://github.com/Helixar-AI/HDP.git",
     "directory": "packages/hdp-physical"
   },
-  "license": "CC-BY-4.0"
+  "license": "Apache-2.0"
 }

--- a/packages/llama-index-callbacks-hdp/README.md
+++ b/packages/llama-index-callbacks-hdp/README.md
@@ -82,4 +82,4 @@ if result.valid:
 
 ## License
 
-CC-BY-4.0
+Apache-2.0

--- a/packages/llama-index-callbacks-hdp/pyproject.toml
+++ b/packages/llama-index-callbacks-hdp/pyproject.toml
@@ -7,7 +7,7 @@ name = "llama-index-callbacks-hdp"
 version = "0.1.0"
 description = "HDP (Human Delegation Provenance) — cryptographic authorization provenance for LlamaIndex agents"
 readme = "README.md"
-license = { text = "CC-BY-4.0" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "llama-index-core>=0.10.20,<0.15",


### PR DESCRIPTION
## Summary

Relicenses the HDP monorepo from **Creative Commons Attribution 4.0 (CC BY 4.0)** to the **Apache License 2.0**.

Apache 2.0 is the more appropriate choice for a software project: it includes an explicit patent grant, a contribution clause, and a well-understood set of redistribution terms — all things CC BY was never designed to cover. It's also the prevailing license across the AI/agent tooling ecosystem HDP integrates with (LangChain, LlamaIndex, CrewAI, AutoGen), which makes downstream integration and redistribution friction-free.

## Changes

- `LICENSE` — replaced with the full Apache 2.0 text, copyright retained by Helixar Limited
- Root `README.md` — updated license badge and "License" section
- `license` field updated in every `package.json` and `pyproject.toml` across `packages/*` (`CC-BY-4.0` → `Apache-2.0`)
- Per-package `README.md` "License" sections updated to Apache 2.0

No source/code logic changes — documentation and metadata only.

## Reviewer

cc @sidnz — requesting your sign-off before merge. You authored the `hdp-langchain` integration, so this relicensing directly affects work you contributed. Please confirm you're good with the change from CC BY 4.0 → Apache 2.0.

## Test plan

- [ ] Confirm `LICENSE` contains the full Apache 2.0 text with Helixar Limited as copyright holder
- [ ] `grep -rn "CC-BY\|CC BY\|creative commons" .` returns no results in tracked source files
- [ ] All `package.json` / `pyproject.toml` `license` fields report `Apache-2.0`
- [ ] @sidnz approves the relicense of contributed Langchain integration code

---
_Generated by [Claude Code](https://claude.ai/code/session_014cDhuajdu5dj6DXUmjHLtY)_